### PR TITLE
mocha timeout is longer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "build": "tsc --project tsconfig.esm.json && tsc --project tsconfig.cjs.json",
-    "test": "npm run build && mocha test/test.js --timeout 10000"
+    "test": "npm run build && mocha test/test.js --timeout 20000"
   },
   "keywords": [
     "javascript",


### PR DESCRIPTION
- this PR resolves #15 

``` diff
-    "test": "npm run build && mocha test/test.js --timeout 10000"
+    "test": "npm run build && mocha test/test.js --timeout 20000"
```
