### PR TITLE
namespace Selen is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Web drivers are installed and the paths for the drivers are ready.
 #### Basics
 You can use ```Selen.Pages.Any``` class for getting started or lightly use.
 ``` typescript
-import { Selen, PageOptions } from "selenium-pages";
+import { Selen } from "selenium-pages";
 
-const pageOptions: PageOptions = {
+const pageOptions: Selen.Options = {
   origin: "https://www.google.com" // home page origin
 };
 
@@ -69,9 +69,9 @@ await driver.quit();
 #### How to extend the base class
 You can extend ```Selen.Pages.Base``` class for your own use.
 ``` typescript
-import { Selen, PageOptions } from "selenium-pages";
+import { Selen } from "selenium-pages";
 
-const pageOptions: PageOptions = {
+const pageOptions: Selen.Options = {
   origin: "https://www.google.com"
 };
 
@@ -101,11 +101,11 @@ await testPage.workSome();
 ```
 
 #### How to use customized options
-You can extend ```PageOptions``` and use it in your class instance methods.
+You can extend ```Selen.Options``` and use it in your class instance methods.
 ``` typescript
-import { Selen, PageOptions } from "selenium-pages";
+import { Selen } from "selenium-pages";
 
-type CustomOptions = PageOptions & {
+type CustomOptions = Selen.Options & {
   some: string;
   testUrl: string;
 };

--- a/src/selen/index.ts
+++ b/src/selen/index.ts
@@ -15,3 +15,7 @@ export class Selen {
     return this.Build(browser);
   }
 }
+
+export namespace Selen {
+  export type Options = SelenOptions;
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,6 @@
 import { WebDriver } from "selenium-webdriver";
 import { describe, it, before, after } from "mocha";
-import { Selen, PageOptions } from "../src/selen/";
+import { Selen } from "../src/selen/";
 import { strict as assert } from "assert";
 
 /*
@@ -9,7 +9,7 @@ Install chromedriver and define PATH to chromedriver before testing
 
 let driver: WebDriver;
 
-const pageOptions: PageOptions = {
+const pageOptions: Selen.Options = {
   origin: "https://www.google.com"
 };
 
@@ -139,6 +139,35 @@ describe("testing", () => {
     assert(
       custom.getCurrentUrl()
         .then(url => url.match(/^https:\/\/www\.google\.com\/.*?q=test.*/i))
+    );
+  });
+
+  it("customized options", async () => {
+    type MyOptions = Selen.Options & {
+      keyword: string;
+    };
+
+    class Custom extends Selen.Pages.Base<MyOptions> {
+      public async test(){
+        await this.goTo(`/q=${this.options.keyword}`);
+      }
+    }
+
+    const custom = new Custom(
+      driver,
+      {
+        ...pageOptions,
+        keyword: "selenium"
+      }
+    );
+
+    await custom.test();
+
+    assert(
+      await custom.getCurrentUrl()
+        .then(url => url.match(
+          /^https:\/\/www\.google\.com\/q=selenium/i
+        ))
     );
   });
 });


### PR DESCRIPTION
```Selen.Options``` can be written likewise below.

``` typescript
import { Selen } from "selenium-pages";

const options: Selen.Options = {
  origin: "..."
};

```

- this PR resolves #21 